### PR TITLE
Refactor and reduce allocations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@
 # editor settings
 .vs/
 .vscode/
+.idea/
+*.DotSettings.user
 
 # build output
 [Bb]in/

--- a/Backdash.Gns/NetcodeSessionBuilderExtensions.cs
+++ b/Backdash.Gns/NetcodeSessionBuilderExtensions.cs
@@ -3,8 +3,8 @@
 
 namespace Backdash.Gns;
 
+using System.Runtime.CompilerServices;
 using Backdash;
-using Backdash.Options;
 using GnsSharp;
 
 /// <summary>
@@ -27,20 +27,12 @@ public static class NetcodeSessionBuilderExtensions
     /// <typeparam name="TInput">Input type.</typeparam>
     /// <param name="builder">Session builder.</param>
     /// <returns>The same session <paramref name="builder"/> passed in the parameter.</returns>
-    public static NetcodeSessionBuilder<TInput> UseGameNetworkingSockets<TInput>(this NetcodeSessionBuilder<TInput> builder)
+    public static NetcodeSessionBuilder<TInput> UseGameNetworkingSockets<TInput>(
+        this NetcodeSessionBuilder<TInput> builder)
         where TInput : unmanaged
     {
-        return builder.ConfigureServices((ServicesConfig<TInput> services) =>
-        {
-            services.PeerSocketFactory = new SteamSocketFactory();
-        })
-        .ConfigureProtocol((ProtocolOptions protocol) =>
-        {
-            unsafe
-            {
-                protocol.ReceiveSocketAddressSize = sizeof(SteamNetworkingIdentity);
-            }
-        })
-        .UsePlugin(new SteamSessionPlugin());
+        return builder.ConfigureServices(services => { services.PeerSocketFactory = new SteamSocketFactory(); })
+            .ConfigureProtocol(protocol => protocol.ReceiveSocketAddressSize = Unsafe.SizeOf<SteamNetworkingIdentity>())
+            .UsePlugin<SteamSessionPlugin>();
     }
 }

--- a/Backdash.Gns/SteamEndPoint.cs
+++ b/Backdash.Gns/SteamEndPoint.cs
@@ -4,6 +4,7 @@
 namespace Backdash.Gns;
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Net;
 using System.Net.Sockets;
 using GnsSharp;
@@ -11,6 +12,7 @@ using GnsSharp;
 /// <summary>
 /// Provides a <see cref="GnsSharp.SteamNetworkingIdentity"/> endpoint.
 /// </summary>
+[Serializable]
 public class SteamEndPoint : EndPoint
 {
     /// <summary>
@@ -37,11 +39,45 @@ public class SteamEndPoint : EndPoint
     /// </summary>
     public int Channel { get; }
 
-    /// <inheritdoc/>
-    public override SocketAddress Serialize()
+    /// <summary>Tries to parse a string into a value.</summary>
+    /// <param name="channel">Steam endpoint channel.</param>
+    /// <param name="s">The string to parse.</param>
+    /// <param name="result">When this method returns, contains the result of successfully parsing <paramref name="s" /> or an undefined value on failure.</param>
+    /// <returns>
+    /// <see langword="true" /> if <paramref name="s" /> was successfully parsed; otherwise, <see langword="false" />.</returns>
+    public static bool TryParse(
+        int channel,
+        [NotNullWhen(true)] string? s,
+        [MaybeNullWhen(false)] out SteamEndPoint result)
     {
-        return this.Identity.ToSocketAddress();
+        SteamNetworkingIdentity identity = default;
+
+        if (s is not null && identity.ParseString(s))
+        {
+            result = new SteamEndPoint(identity, channel);
+            return true;
+        }
+
+        result = null;
+        return false;
     }
+
+    /// <summary>Parses a string into a value.</summary>
+    /// <param name="channel">Steam endpoint channel.</param>
+    /// <param name="s">The string to parse.</param>
+    /// <returns>The result of parsing <paramref name="s" />.</returns>
+    public static SteamEndPoint Parse(int channel, string s)
+    {
+        if (!TryParse(channel, s, out var endPoint))
+        {
+            throw new InvalidOperationException($"Invalid Steam endpoint: {s}");
+        }
+
+        return endPoint;
+    }
+
+    /// <inheritdoc/>
+    public override SocketAddress Serialize() => this.Identity.ToSocketAddress();
 
     /// <inheritdoc/>
     public override EndPoint Create(SocketAddress socketAddress) => throw new NotImplementedException();

--- a/Backdash.Gns/SteamSocket.cs
+++ b/Backdash.Gns/SteamSocket.cs
@@ -6,6 +6,7 @@ namespace Backdash.Gns;
 using System;
 using System.Net;
 using System.Net.Sockets;
+using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 using Backdash.Network.Client;
@@ -17,7 +18,6 @@ using GnsSharp;
 public sealed class SteamSocket : IPeerSocket
 {
     private readonly ISteamNetworkingMessages steamNetMsgs;
-
     private readonly int channel;
 
     /// <summary>
@@ -50,55 +50,35 @@ public sealed class SteamSocket : IPeerSocket
     /// </param>
     /// <param name="cancellationToken">Cancellation token to cancel the operation.</param>
     /// <returns><see cref="ValueTask"/> containing receive task.</returns>
-    public ValueTask<int> ReceiveFromAsync(Memory<byte> buffer, SocketAddress address, CancellationToken cancellationToken)
+    [AsyncMethodBuilder(typeof(PoolingAsyncValueTaskMethodBuilder<>))]
+    public async ValueTask<int> ReceiveFromAsync(
+        Memory<byte> buffer, SocketAddress address, CancellationToken cancellationToken)
     {
-        return new ValueTask<int>(Task.Run<int>(
-            async () =>
+        const int numberOfSyncSpins = 10;
+        SpinWait spin = default;
+
+        for (var i = 0; i < numberOfSyncSpins; i++)
+        {
+            if (this.TryReceiveMessageOnChannel(buffer.Span, in address, out var size))
             {
-                IntPtr[] msgPtrs = new IntPtr[1];
+                return size;
+            }
 
-                try
-                {
-                    while (true)
-                    {
-                        int msgReceived = this.steamNetMsgs.ReceiveMessagesOnChannel(this.Port, msgPtrs);
-                        if (msgReceived != 0)
-                        {
-                            break;
-                        }
+            if (spin.NextSpinWillYield)
+            {
+                spin.SpinOnce();
+                continue;
+            }
 
-                        await Task.Delay(1, cancellationToken);
-                    }
+            break;
+        }
 
-                    int payloadSize;
-                    unsafe
-                    {
-                        ref readonly var msg = ref new ReadOnlySpan<SteamNetworkingMessage_t>((void*)msgPtrs[0], 1)[0];
-                        payloadSize = msg.Size;
-
-                        ReadOnlySpan<byte> payload = new((void*)msg.Data, msg.Size);
-                        payload.CopyTo(buffer.Span);
-
-                        ref var identity = ref address.AsSteamNetworkingIdentity();
-
-                        identity = msg.IdentityPeer;
-                    }
-
-                    return payloadSize;
-                }
-                finally
-                {
-                    if (msgPtrs[0] != IntPtr.Zero)
-                    {
-                        SteamNetworkingMessage_t.Release(msgPtrs[0]);
-                    }
-                }
-            },
-            cancellationToken));
+        return await this.ReceiveMessageOnChannelAsync(buffer, address, cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
-    public ValueTask<SocketReceiveFromResult> ReceiveAsync(Memory<byte> buffer, CancellationToken cancellationToken) => throw new NotImplementedException();
+    public ValueTask<SocketReceiveFromResult> ReceiveAsync(Memory<byte> buffer, CancellationToken cancellationToken) =>
+        throw new NotImplementedException();
 
     /// <summary>
     /// Sends data to the specified steam networking identity host.
@@ -110,22 +90,29 @@ public sealed class SteamSocket : IPeerSocket
     /// </param>
     /// <param name="cancellationToken">A cancellation token that can be used to cancel the asynchronous operation.</param>
     /// <returns><see cref="ValueTask"/> containing send task.</returns>
-    public ValueTask<int> SendToAsync(ReadOnlyMemory<byte> buffer, SocketAddress socketAddress, CancellationToken cancellationToken)
+    public ValueTask<int> SendToAsync(
+        ReadOnlyMemory<byte> buffer, SocketAddress socketAddress, CancellationToken cancellationToken)
     {
-        ref SteamNetworkingIdentity identity = ref socketAddress.AsSteamNetworkingIdentity();
+        ref var identity = ref socketAddress.AsSteamNetworkingIdentity();
 
-        EResult result = this.steamNetMsgs.SendMessageToUser(identity, buffer.Span, ESteamNetworkingSendType.UnreliableNoNagle | ESteamNetworkingSendType.AutoRestartBrokenSession, this.Port);
+        var result = this.steamNetMsgs.SendMessageToUser(
+            identity,
+            buffer.Span,
+            ESteamNetworkingSendType.UnreliableNoNagle | ESteamNetworkingSendType.AutoRestartBrokenSession,
+            this.Port);
 
-        if (result != EResult.OK)
+        if (result is not EResult.OK)
         {
             return ValueTask.FromException<int>(new SteamEResultException(result));
         }
 
-        return ValueTask.FromResult<int>(buffer.Length);
+        return ValueTask.FromResult(buffer.Length);
     }
 
     /// <inheritdoc/>
-    public ValueTask<int> SendToAsync(ReadOnlyMemory<byte> buffer, EndPoint remoteEndPoint, CancellationToken cancellationToken) => throw new NotImplementedException();
+    public ValueTask<int> SendToAsync(
+        ReadOnlyMemory<byte> buffer, EndPoint remoteEndPoint, CancellationToken cancellationToken) =>
+        throw new NotImplementedException();
 
     /// <inheritdoc/>
     public void Dispose()
@@ -136,4 +123,58 @@ public sealed class SteamSocket : IPeerSocket
     public void Close()
     {
     }
+
+    private unsafe bool TryReceiveMessageOnChannel(Span<byte> buffer, in SocketAddress address, out int payloadSize)
+    {
+        Span<nint> msgPtrs = stackalloc nint[1];
+
+        try
+        {
+            var msgReceived = this.steamNetMsgs.ReceiveMessagesOnChannel(this.Port, msgPtrs);
+
+            if (msgReceived is 0)
+            {
+                payloadSize = 0;
+                return false;
+            }
+
+            ref readonly var msg = ref Unsafe.AsRef<SteamNetworkingMessage_t>(msgPtrs[0].ToPointer());
+            payloadSize = msg.Size;
+
+            ReadOnlySpan<byte> payload = new(msg.Data.ToPointer(), msg.Size);
+            payload.CopyTo(buffer);
+
+            ref var identity = ref address.AsSteamNetworkingIdentity();
+            identity = msg.IdentityPeer;
+            return true;
+        }
+        finally
+        {
+            if (msgPtrs[0] != nint.Zero)
+            {
+                SteamNetworkingMessage_t.Release(msgPtrs[0]);
+            }
+        }
+    }
+
+    private Task<int> ReceiveMessageOnChannelAsync(
+        Memory<byte> buffer,
+        SocketAddress address,
+        CancellationToken cancellationToken) =>
+        Task.Run(
+            async () =>
+            {
+                while (!cancellationToken.IsCancellationRequested)
+                {
+                    if (this.TryReceiveMessageOnChannel(buffer.Span, in address, out var size))
+                    {
+                        return size;
+                    }
+
+                    await Task.Yield();
+                }
+
+                return 0;
+            },
+            cancellationToken);
 }

--- a/Backdash.Gns/SteamSocketFactory.cs
+++ b/Backdash.Gns/SteamSocketFactory.cs
@@ -21,9 +21,10 @@ internal sealed class SteamSocketFactory : IPeerSocketFactory
     /// <returns><see cref="IPeerSocket"/> that is <see cref="SteamSocket"/>.</returns>
     public IPeerSocket Create(int channel, NetcodeOptions options)
     {
-        if (ISteamNetworkingMessages.User == null)
+        if (ISteamNetworkingMessages.User is null)
         {
-            throw new InvalidOperationException("ISteamNetworkingMessages.User is null. Call SteamAPI.Init() or SteamAPI.InitEx() beforehand.");
+            throw new InvalidOperationException(
+                "ISteamNetworkingMessages.User is null. Call SteamAPI.Init() or SteamAPI.InitEx() beforehand.");
         }
 
         return new SteamSocket(channel, ISteamNetworkingMessages.User);

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -39,7 +39,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Backdash" Version="0.6.10-preview" />
+    <PackageReference Include="Backdash" Version="0.6.12-preview" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
- some clean-up
- Reduce `Task` allocations on `ReceiveFromAsync`, only deferring to async call when no result is available immediately


> [!NOTE]
> I was not able to test it, but it should work